### PR TITLE
[Security] Improve profiler’s panel

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Debug/TraceableFirewallListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/TraceableFirewallListener.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\Service\ResetInterface;
 final class TraceableFirewallListener extends FirewallListener implements ResetInterface
 {
     private array $wrappedListeners = [];
-    private array $authenticatorsInfo = [];
+    private ?TraceableAuthenticatorManagerListener $authenticatorManagerListener = null;
 
     public function getWrappedListeners(): array
     {
@@ -39,62 +39,60 @@ final class TraceableFirewallListener extends FirewallListener implements ResetI
 
     public function getAuthenticatorsInfo(): array
     {
-        return $this->authenticatorsInfo;
+        return $this->authenticatorManagerListener?->getAuthenticatorsInfo() ?? [];
     }
 
     public function reset(): void
     {
         $this->wrappedListeners = [];
-        $this->authenticatorsInfo = [];
+        $this->authenticatorManagerListener = null;
     }
 
     protected function callListeners(RequestEvent $event, iterable $listeners): void
     {
-        $wrappedListeners = [];
-        $authenticatorManagerListener = null;
-
+        $requestListeners = [];
         foreach ($listeners as $listener) {
             if ($listener instanceof LazyFirewallContext) {
-                \Closure::bind(function () use (&$wrappedListeners, &$authenticatorManagerListener) {
-                    $listeners = [];
+                $contextWrappedListeners = [];
+                $contextAuthenticatorManagerListener = null;
+
+                \Closure::bind(function () use (&$contextWrappedListeners, &$contextAuthenticatorManagerListener) {
                     foreach ($this->listeners as $listener) {
-                        if (!$authenticatorManagerListener && $listener instanceof TraceableAuthenticatorManagerListener) {
-                            $authenticatorManagerListener = $listener;
+                        if ($listener instanceof TraceableAuthenticatorManagerListener) {
+                            $contextAuthenticatorManagerListener ??= $listener;
                         }
-                        if ($listener instanceof FirewallListenerInterface) {
-                            $listener = new WrappedLazyListener($listener);
-                            $listeners[] = $listener;
-                            $wrappedListeners[] = $listener;
-                        } else {
-                            $listeners[] = function (RequestEvent $event) use ($listener, &$wrappedListeners) {
-                                $wrappedListener = new WrappedListener($listener);
-                                $wrappedListener($event);
-                                $wrappedListeners[] = $wrappedListener;
-                            };
-                        }
+                        $contextWrappedListeners[] = $listener instanceof FirewallListenerInterface
+                            ? new WrappedLazyListener($listener)
+                            : new WrappedListener($listener)
+                        ;
                     }
-                    $this->listeners = $listeners;
+                    $this->listeners = $contextWrappedListeners;
                 }, $listener, FirewallContext::class)();
 
-                $listener($event);
+                $this->authenticatorManagerListener ??= $contextAuthenticatorManagerListener;
+                $this->wrappedListeners = array_merge($this->wrappedListeners, $contextWrappedListeners);
+
+                $requestListeners[] = $listener;
             } else {
-                $wrappedListener = $listener instanceof FirewallListenerInterface ? new WrappedLazyListener($listener) : new WrappedListener($listener);
-                $wrappedListener($event);
-                $this->wrappedListeners[] = $wrappedListener;
-                if (!$authenticatorManagerListener && $listener instanceof TraceableAuthenticatorManagerListener) {
-                    $authenticatorManagerListener = $listener;
+                if ($listener instanceof TraceableAuthenticatorManagerListener) {
+                    $this->authenticatorManagerListener ??= $listener;
                 }
+                $wrappedListener = $listener instanceof FirewallListenerInterface
+                    ? new WrappedLazyListener($listener)
+                    : new WrappedListener($listener)
+                ;
+                $this->wrappedListeners[] = $wrappedListener;
+
+                $requestListeners[] = $wrappedListener;
             }
+        }
+
+        foreach ($requestListeners as $listener) {
+            $listener($event);
 
             if ($event->hasResponse()) {
                 break;
             }
-        }
-
-        $this->wrappedListeners = array_merge($this->wrappedListeners, $wrappedListeners);
-
-        if ($authenticatorManagerListener) {
-            $this->authenticatorsInfo = $authenticatorManagerListener->getAuthenticatorsInfo();
         }
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -318,7 +318,7 @@
 
                                 <tr>
                                     <td class="font-normal">{{ profiler_dump(listener.stub) }}</td>
-                                    <td class="no-wrap">{{ '%0.2f'|format(listener.time * 1000) }} ms</td>
+                                    <td class="no-wrap">{{ listener.time is null ? '(none)' : '%0.2f ms'|format(listener.time * 1000) }}</td>
                                     <td class="font-normal">{{ listener.response ? profiler_dump(listener.response) : '(none)' }}</td>
                                 </tr>
 
@@ -362,7 +362,7 @@
                                     <td class="font-normal">{{ profiler_dump(authenticator.stub) }}</td>
                                     <td class="no-wrap">{{ source('@WebProfiler/Icon/' ~ (authenticator.supports ? 'yes' : 'no') ~ '.svg') }}</td>
                                     <td class="no-wrap">{{ authenticator.authenticated is not null ? source('@WebProfiler/Icon/' ~ (authenticator.authenticated ? 'yes' : 'no') ~ '.svg') : '' }}</td>
-                                    <td class="no-wrap">{{ '%0.2f'|format(authenticator.duration * 1000) }} ms</td>
+                                    <td class="no-wrap">{{ authenticator.duration is null ? '(none)' : '%0.2f ms'|format(authenticator.duration * 1000) }}</td>
                                     <td class="font-normal">{{ authenticator.passport ? profiler_dump(authenticator.passport) : '(none)' }}</td>
                                     <td class="font-normal">
                                         {% for badge in authenticator.badges ?? [] %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Let’s display the profiler for a request matching a lone lazy firewall:

```yaml
firewalls:
    main:
        lazy: true
```

Since no channel is forced, we know the `ChannelListener` did not run. To make it more obvious, this PR displays `(none)` instead of `0.00 ms` when the duration is null.

<details>
<summary>Before</summary>
<img src="https://github.com/MatTheCat/symfony/assets/1898254/d8168db1-2a6d-46d9-8fd2-597182327f2f" alt="">
</details>
<details>
<summary>After</summary>
<img src="https://github.com/MatTheCat/symfony/assets/1898254/8bf2345a-5e33-4674-863e-e3a40d30f15a" alt="">
</details>

But what about the `ContextListener`? Since the firewall is stateful we know it ran, yet its displayed duration also is `0.00 ms`.
Turns out that because the firewall is lazy, the `ContextListener` ran way past the moment the `TraceableFirewallListener` stored its data. In fact, it may be the `SecurityDataCollector` itself which trigger it by accessing the security token. This PR makes the `TraceableFirewallListener` fetch data only when needed, so that they’re up-to-date when the `SecurityDataCollector` asks for them.

<details>
<summary>Before</summary>
<img src="https://github.com/MatTheCat/symfony/assets/1898254/312ee207-7607-4f15-9126-4adc1c14a6bf" alt="">
</details>
<details>
<summary>After</summary>
<img src="https://github.com/MatTheCat/symfony/assets/1898254/0e141294-365c-4ae7-8dc7-d0c390ab700f" alt="">
</details>

Now, let’s add a global access control so that the `AccessListener` can do its job:

```yaml
access_control:
    - { roles: ROLE_USER }
```

The profiler then says no security listeners have been recorded :thinking: 

This is because the `AccessListener` let the `ExceptionListener` work out a response by throwing `AccessDeniedException`s. When this happens, the `TraceableFirewallListener` is cut short before it can store the data it needs (note that it also impacts non-lazy firewalls, but past listeners would then be recorded).

This PR stores these data before listeners are called, so that they are available even if one of them throws (this includes authenticators’ data which suffer from the same issue).

<details>
<summary>Before</summary>
<img src="https://github.com/MatTheCat/symfony/assets/1898254/4846ad06-007c-4ff0-ae69-4841bfdf90a2" alt="">
</details>
<details>
<summary>After</summary>
<img src="https://github.com/MatTheCat/symfony/assets/1898254/405dabed-e6aa-4252-8c5f-48d00174f7fd" alt="">
<p>(Other listeners are hidden on this screenshot but they would be displayed in the profiler.)</p>
</details>
